### PR TITLE
Switch to prop-types package

### DIFF
--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, createElement } from 'react';
+import React, { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
 
 export default class App extends Component {
   constructor(...args) {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
-    "react": "*",
+    "react": "15.x || 16.x",
     "react-addons-pure-render-mixin": "^15.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   ],
   "dependencies": {
     "immutable": "^3.7.6",
-    "lodash": "^4.6.1"
+    "lodash": "^4.6.1",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",
@@ -77,7 +78,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
-    "react": "^15.0.0",
+    "react": "*",
     "react-addons-pure-render-mixin": "^15.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes, createElement} from 'react';
+import React, {Component, createElement} from 'react';
+import PropTypes from 'prop-types';
 import Immutable, { Map, List } from 'immutable';
 import assign from 'lodash/assign';
 import get from 'lodash/fp/get';


### PR DESCRIPTION
React no longer exports PropTypes property, 'prop-types' package must be used instead.